### PR TITLE
Added options mode, ignore, stdout

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,11 +45,37 @@ Default: '%s (suggestions: %s)'
 
 The string that will replace the wrong word whereas the first placeholder is the wrong word and the second placeholder a list of suggestions.
 
+##### stdout
+Type: `Boolean`
+Default: 'false'
+
+Print spelling errors to stdout instead of altering the stream.
+
+##### hideSuggestions
+Type: `Boolean`
+Default: 'false'
+
+Hide suggestions when using stdout.
+
+##### mode
+Type: `String`
+Default: 'none'
+
+Choose aspell mode. See [GNU Aspell Documentation](http://aspell.net/man-html/Notes-on-Various-Filters-and-Filter-Modes.html#Notes-on-Various-Filters-and-Filter-Modes) for details.
+
+##### ignore
+Type: `Array` (of `Array`s)
+Default: '[]'
+
+List of words to be ignored.
+
 ## Changelog
 
-### Version 0.2.0 (Future)
+### Version 0.2.0 (20150624)
 
-- Ignore list
+- Added ignore list option
+- Added options hideSuggestions, mode and stdout
+- Improved output to include line and column number
 
 ### Version 0.1.2 (20140331)
 

--- a/index.js
+++ b/index.js
@@ -41,7 +41,6 @@ module.exports = function (options) {
         aspell((options.ignore || []).map(function(str) { return util.format("@%s\n", str); }).join("") + '^' + contents.replace(/\r?\n/g, '^\n'))
             .on('error', function onError (err) {
                 err = err.toString('utf-8');
-
                 return self.emit('error', new gutil.PluginError(PLUGIN_NAME, err));
             })
             .on('result', function onResult (result) {
@@ -50,7 +49,7 @@ module.exports = function (options) {
                         gutil.log(gutil.colors.red("Misspelling:"),
                             file.relative,
                             util.format("Line %s, Column %s", line, result.position + 1),
-                            util.format(options.replacement, gutil.colors.red.bold(result.word), result.alternatives.join(', ')));
+                            options.hideSuggestions ? gutil.colors.red.bold(result.word) : util.format(options.replacement, gutil.colors.red.bold(result.word), result.alternatives.join(', ')));
                     } else {
                         contents = contents.replace(result.word, util.format(options.replacement, result.word, result.alternatives.join(', ')));
                     }

--- a/index.js
+++ b/index.js
@@ -25,8 +25,10 @@ module.exports = function (options) {
     options.replacement = options.replacement || '%s (suggestions: %s)';
 
     options.language = (options.language)? util.format('--lang=%s', options.language) : '';
+    options.mode = (options.mode)? util.format('--mode=%s', options.mode) : '';
 
     aspell.args.push(options.language);
+    aspell.args.push(options.mode);
 
     function check (file, enc, callback) {
         /*jshint validthis:true */
@@ -35,7 +37,8 @@ module.exports = function (options) {
 
         // Remove all line breaks and add a circumflex in order to disable 'pipe mode'.
         // see: http://aspell.net/man-html/Through-A-Pipe.html
-        aspell('^' + contents.replace(/\r?\n/g, ''))
+        var line = 1;
+        aspell((options.ignore || []).map(function(str) { return util.format("@%s\n", str); }).join("") + '^' + contents.replace(/\r?\n/g, '^\n'))
             .on('error', function onError (err) {
                 err = err.toString('utf-8');
 
@@ -43,11 +46,22 @@ module.exports = function (options) {
             })
             .on('result', function onResult (result) {
                 if ('misspelling' === result.type) {
-                    contents = contents.replace(result.word, util.format(options.replacement, result.word, result.alternatives.join(', ')));
+                    if (options.stdout) {
+                        gutil.log(gutil.colors.red("Misspelling:"),
+                            file.relative,
+                            util.format("Line %s, Column %s", line, result.position + 1),
+                            util.format(options.replacement, gutil.colors.red.bold(result.word), result.alternatives.join(', ')));
+                    } else {
+                        contents = contents.replace(result.word, util.format(options.replacement, result.word, result.alternatives.join(', ')));
+                    }
+                } else if ('line-break' === result.type) {
+                    line++;
                 }
             })
             .on('end', function () {
-                file.contents = new Buffer(contents);
+                if (!options.stdout) {
+                    file.contents = new Buffer(contents);
+                }
                 self.push(file);
 
                 return callback();

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "gulp-spellcheck",
   "description": "A gulp plugin for spell-checking with GNU Aspell.",
-  "version": "0.1.2",
+  "version": "0.2.0",
   "author": {
     "name": "André König",
     "email": "andre.koenig@posteo.de"


### PR DESCRIPTION
- mode (string): e.g. for checking html using aspell mode=sgml
- ignore (array): words to be ignored
- stdout (boolean, default false): print misspellings to std instead of altering the stream
- Shows line and column number in output
